### PR TITLE
fix: accept contract addresses as pool address (#1165)

### DIFF
--- a/app/pages/stacking/delegated-stacking/pooled-stacking.tsx
+++ b/app/pages/stacking/delegated-stacking/pooled-stacking.tsx
@@ -12,7 +12,7 @@ import { useBackButton } from '@hooks/use-back-url';
 import { DelegatedStackingModal } from '@modals/delegated-stacking/delegated-stacking-modal';
 import { selectNextCycleInfo, selectPoxInfo } from '@store/stacking';
 import { calculateUntilBurnHeightBlockFromCycles } from '@utils/calculate-burn-height';
-import { stxAddressSchema } from '@utils/validators/stx-address-validator';
+import { stxPrincipalSchema } from '@utils/validators/stx-address-validator';
 import {
   UI_IMPOSED_MAX_STACKING_AMOUNT_USTX,
   MIN_DELEGATED_STACKING_AMOUNT_USTX,
@@ -83,7 +83,7 @@ export const StackingDelegation: FC = () => {
   );
 
   const validationSchema = yup.object().shape({
-    stxAddress: stxAddressSchema().test({
+    stxAddress: stxPrincipalSchema().test({
       name: 'cannot-pool-to-yourself',
       message: 'Cannot pool to your own STX address',
       test(value: any) {

--- a/app/utils/get-stx-transfer-direction.ts
+++ b/app/utils/get-stx-transfer-direction.ts
@@ -23,7 +23,7 @@ export const validateStacksAddress = (stacksAddress: string): boolean => {
 
 export const validateStacksPrincipal = (contractId: string): boolean => {
   try {
-    const [stacksAddress] = contractId.split(".")
+    const [stacksAddress] = contractId.split('.');
     c32addressDecode(stacksAddress);
     return true;
   } catch (e) {

--- a/app/utils/get-stx-transfer-direction.ts
+++ b/app/utils/get-stx-transfer-direction.ts
@@ -20,3 +20,13 @@ export const validateStacksAddress = (stacksAddress: string): boolean => {
     return false;
   }
 };
+
+export const validateStacksPrincipal = (contractId: string): boolean => {
+  try {
+    const [stacksAddress] = contractId.split(".")
+    c32addressDecode(stacksAddress);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};

--- a/app/utils/validators/stx-address-validator.ts
+++ b/app/utils/validators/stx-address-validator.ts
@@ -1,9 +1,10 @@
 import * as yup from 'yup';
-import { validateStacksAddress } from '../get-stx-transfer-direction';
+import { validateStacksPrincipal } from '../get-stx-transfer-direction';
 import { validateAddressChain } from '../../crypto/validate-address-net';
 import { NETWORK } from '@constants/index';
 
-export function stxAddressSchema() {
+// accepts standard and contract addresses
+export function stxPrincipalSchema() {
   let timer = 0;
   return yup
     .string()
@@ -15,7 +16,7 @@ export function stxAddressSchema() {
           clearTimeout(timer);
           timer = window.setTimeout(() => {
             if (!value) return resolve(false);
-            const valid = validateStacksAddress(value);
+            const valid = validateStacksPrincipal(value);
 
             if (!valid) {
               return resolve(


### PR DESCRIPTION
This PR
* relaxes the validation of pool addresses so that contracts can be entered as pool address
* fixes #1165 

This is the only change needed so that users can join Fast Pool (aka Friedger Pool) with the Desktop Wallet