### PR TITLE
fix: pooling card amount, closes #1150

### DIFF
--- a/app/hooks/use-delegation-status.ts
+++ b/app/hooks/use-delegation-status.ts
@@ -6,7 +6,6 @@ import { RootState } from '@store/index';
 import { selectAddress } from '@store/keys';
 import { selectPoxInfo } from '@store/stacking';
 import BigNumber from 'bignumber.js';
-import BN from 'bn.js';
 import { useSelector } from 'react-redux';
 
 interface DelegatedTrueStatus {
@@ -39,9 +38,9 @@ export function useDelegationStatus(): DelegatedStatus {
   if (resp.type === ClarityType.OptionalSome && resp.value.type === ClarityType.Tuple) {
     const data = resp.value.data;
 
-    const amountMicroStx = BN.isBN((data['amount-ustx'] as any).value)
-      ? new BigNumber((data['amount-ustx'] as any).value.toString())
-      : new BigNumber(0);
+    const ustxAmount = (data['amount-ustx'] as any).value;
+
+    const amountMicroStx = ustxAmount ? new BigNumber(ustxAmount) : new BigNumber(0);
 
     const untilBurnHeight =
       data['until-burn-ht'].type === ClarityType.OptionalSome


### PR DESCRIPTION
> [Download the latest build](https://github.com/hirosystems/desktop-wallet/actions/runs/4718932579)<!-- Sticky Header Marker -->

We used to get a value back from the stacking library that we no longer do (defaults to 0).  Rather than showing the amount that the user allowed to delegate, we show the amount currently locked.

